### PR TITLE
Remove Documenter dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Parquet2 = "98572fba-bba0-415d-956f-fa77e587d26d"
 RData = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
@@ -31,7 +30,8 @@ RData = "1.0"
 julia = "1.9"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Documenter", "Test"]


### PR DESCRIPTION
I saw this in the deps and as far as I can tell this is by accident, since Documenter is only used in the tests and docs, but not the package itself.